### PR TITLE
Add "Published projects" to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,6 @@ More sponsors mean we can spend more time on open-source.
 
 ## Projects
 
-* [**clue/framework-x**](https://github.com/clue/framework-x) –
-  Framework X – the simple and fast micro framework for building reactive web applications that run anywhere.
-
-  [![framework-x](framework-x.jpeg)](https://framework-x.clue.engineering/)
-
 * [**clue/reactphp-pq**](https://github.com/clue/reactphp-pq) –
   PQ ("peak"), automatically wrap blocking functions in an async child process and turn blocking functions into non-blocking promises,
   built on top of [ReactPHP](https://reactphp.org/).
@@ -54,6 +49,15 @@ More sponsors mean we can spend more time on open-source.
 
 * **More to be announced** 🤫 –
   If you're impatient, follow us on Twitter.
+
+## Published projects
+
+Thanks to our sponsors we were able to publish the following projects.
+
+* [**clue/framework-x**](https://github.com/clue/framework-x) –
+  Framework X – the simple and fast micro framework for building reactive web applications that run anywhere.
+
+  [![framework-x](framework-x.jpeg)](https://framework-x.clue.engineering/)
 
 ## You want to be part of clue·access? Become a sponsor!
 


### PR DESCRIPTION
Framework X is no longer early access, but it's still worth mentioning that at one point it was.
Builds on top of #7 and #9.